### PR TITLE
chore(cliff): match cv-* release tags in changelog config

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -75,7 +75,7 @@ protect_breaking_commits = false
 # filter out the commits that are not matched by commit parsers
 filter_commits = false
 # regex for matching git tags
-tag_pattern = "v[0-9].*"
+tag_pattern = "cv-[0-9].*"
 # regex for skipping tags
 skip_tags = "v0.1.0-beta.1"
 # regex for ignoring tags


### PR DESCRIPTION
## What

Change `cliff.toml` `tag_pattern` from `v[0-9].*` to `cv-[0-9].*`.

## Why

Every release tag in this repo is `cv-X.Y.Z` (`cv-4.13.0`, `cv-4.12.0`, …). The old pattern `v[0-9].*` requires a `v` immediately followed by a digit, so it matches **none** of them — git-cliff detects zero releases and can't segment the changelog by version.

## Verification

Ran `git-cliff` locally (v2.13.1):

- **Old** `v[0-9].*` → no `## [version]` sections at all (empty).
- **New** `cv-[0-9].*` → correctly detects every release:
  ```
  ## [cv-4.13.0] - 2026-01-29
  ## [cv-4.12.0] - 2025-07-05
  ## [cv-4.10.0] - 2024-06-09
  ## [cv-4.9.0]  - 2024-01-17
  ## [cv-4.8.1]  - 2024-01-10
  ```

Header format is unchanged (still `cv-X.Y.Z`, matching the current CHANGELOG). Changelog regeneration itself happens at release time (`cv-5.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)