### PR TITLE
build(app): drive defaultConfig versions from the version catalog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,14 +11,14 @@ val gitCommitHash = providers.of(GitVersionValueSource::class) {}.get()
 android {
 
     namespace = "com.os.cvCamera"
-    compileSdk = 36
+    compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
         applicationId = "com.os.cvCamera"
-        minSdk = 24
-        targetSdk = 36
-        versionCode = 1
-        versionName = "1.1.0"
+        minSdk = libs.versions.minSdk.get().toInt()
+        targetSdk = libs.versions.targetSdk.get().toInt()
+        versionCode = libs.versions.versionCode.get().toInt()
+        versionName = libs.versions.versionName.get()
 
         buildConfigField("String", "GIT_HASH", "\"$gitCommitHash\"")
 


### PR DESCRIPTION
## What

Read `compileSdk`, `minSdk`, `targetSdk`, `versionCode` and `versionName` in `app/build.gradle.kts` from `gradle/libs.versions.toml` instead of hardcoding them.

```kotlin
compileSdk  = libs.versions.compileSdk.get().toInt()
minSdk      = libs.versions.minSdk.get().toInt()
targetSdk   = libs.versions.targetSdk.get().toInt()
versionCode = libs.versions.versionCode.get().toInt()
versionName = libs.versions.versionName.get()
```

## Why

The catalog already declared all of these, but the build ignored them and hardcoded its own — and they had **drifted**: the build said `versionName = "1.1.0"` / `versionCode = 1`, while the catalog said `2.0.0` / `2`. One source of truth removes the drift.

## Heads-up

Because the catalog wins, the **effective app version becomes `2.0.0` (versionCode 2)** — a monotonic bump, safe for Play. If you'd rather ship a different number, just edit `versionCode`/`versionName` in `libs.versions.toml`. SDK levels are unchanged (both sources already said 36/24/36).

CI (`android-ci-debug`) validates the assembled build with the OpenCV SDK downloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)