### PR TITLE
chore(renovate): use config:recommended preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:base"
+        "config:recommended"
     ]
 }


### PR DESCRIPTION
## What

`renovate.json`: `config:base` → `config:recommended`.

## Why

`config:base` is deprecated — Renovate renamed it to `config:recommended`. Same behavior, current name (silences the deprecation notice Renovate posts on the dependency dashboard).

## Not included

I deliberately did **not** add a custom regex manager for the OpenCV version in `setupOpenCV_*.sh` / README. An OpenCV bump isn't a one-line string change — it also renames the versioned SDK folder (`opencvsdk4130` → …) and needs matching patch/setup updates, so an automated version-only PR would break the build. OpenCV bumps stay manual (handled by the OpenCV 5 upgrade PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)