### PR TITLE
chore(setup): remove dead GITHUB_ACTIONS branch in setupOpenCV_4x.sh

### DIFF
--- a/setupOpenCV_4x.sh
+++ b/setupOpenCV_4x.sh
@@ -4,22 +4,12 @@ wget -O opencv-4.13.0-android-sdk.zip https://github.com/opencv/opencv/releases/
 unzip -qq opencv-4.13.0-android-sdk.zip
 mv OpenCV-android-sdk opencvsdk4130
 
-# Apply OpenCV Build.gradle and Manifest patch
-# ENVIRONMENT VARIABLES check for Github Action CI exist do patching
-if [ -n "$GITHUB_ACTIONS" ]; then
-    echo "GITHUB_ACTIONS is set"
-    echo "Patching OpenCV Build.gradle and Manifest"
-    patch opencvsdk4130/sdk/build.gradle patches/cv_build_gradle_4x.diff
-    patch opencvsdk4130/sdk/java/AndroidManifest.xml patches/manifest_lint.diff
-    echo "Copying OpenCV Lint Baseline"
-    cp patches/opencv-lint-baseline.xml opencvsdk4130/sdk/opencv-lint-baseline.xml
-    # patch opencvsdk4130/sdk/java/src/org/opencv/core/MatAt.kt patches/cv_matat_kt.diff
-else
-    echo "GITHUB_ACTIONS is not set"
-    echo "Patching OpenCV Build.gradle and Manifest"
-    patch opencvsdk4130/sdk/build.gradle patches/cv_build_gradle_4x.diff
-    patch opencvsdk4130/sdk/java/AndroidManifest.xml patches/manifest_lint.diff
-    echo "Copying OpenCV Lint Baseline"
-    cp patches/opencv-lint-baseline.xml opencvsdk4130/sdk/opencv-lint-baseline.xml
-    # patch opencvsdk4130/sdk/java/src/org/opencv/core/MatAt.kt patches/cv_matat_kt.diff
-fi
+# Apply OpenCV Build.gradle + Manifest patches and copy the lint baseline.
+# (Same steps in CI and locally; the previous GITHUB_ACTIONS if/else branches
+#  were identical, so the conditional has been removed.)
+echo "Patching OpenCV Build.gradle and Manifest"
+patch opencvsdk4130/sdk/build.gradle patches/cv_build_gradle_4x.diff
+patch opencvsdk4130/sdk/java/AndroidManifest.xml patches/manifest_lint.diff
+echo "Copying OpenCV Lint Baseline"
+cp patches/opencv-lint-baseline.xml opencvsdk4130/sdk/opencv-lint-baseline.xml
+# patch opencvsdk4130/sdk/java/src/org/opencv/core/MatAt.kt patches/cv_matat_kt_old_patch.diff


### PR DESCRIPTION
## What

Collapse the `if [ -n "$GITHUB_ACTIONS" ]; then … else … fi` in `setupOpenCV_4x.sh` into a single code path.

## Why

Both branches ran the **identical** three commands (patch build.gradle, patch manifest, copy lint baseline). The conditional and the duplicated block added nothing. Behavior is unchanged in CI and locally.

Also corrected the commented-out MatAt patch reference from the non-existent `cv_matat_kt.diff` to the real `cv_matat_kt_old_patch.diff`, so it works if ever uncommented.

## Notes

- The `opencvsdk500/` `.gitignore` entry and the new `setupOpenCV_5x.sh` come with the OpenCV 5 upgrade PR (kept separate).
- Leftover local `opencv-4.10.0/4.12.0-android-sdk.zip` (~620 MB) are already `.gitignore`d; delete them locally to reclaim space if you like.


